### PR TITLE
- add helper for plug-and-play

### DIFF
--- a/src/BlockRadixSortKeyValue.compute
+++ b/src/BlockRadixSortKeyValue.compute
@@ -10,6 +10,7 @@
  ******************************************************************************/
 #pragma use_dxc
 #pragma kernel InitBlockRadixSortKeyValue
+#pragma kernel InitDescending
 #pragma kernel InitRandom
 #pragma kernel InitStability
 #pragma kernel GlobalHistogram
@@ -83,6 +84,13 @@ groupshared uint g_waveHists[BIN_PART_SIZE];                        //Shared mem
 
 [numthreads(1024, 1, 1)]
 void InitBlockRadixSortKeyValue(int3 id : SV_DispatchThreadID)
+{
+    for (int i = id.x; i < 1024; i += 1024 * 256)
+        b_globalHist[i] = 0;
+}
+
+[numthreads(1024, 1, 1)]
+void InitDescending(int3 id : SV_DispatchThreadID)
 {
     for (int i = id.x; i < e_size; i += 1024 * 256)
     {

--- a/src/BlockRadixSortKeyValue.cs
+++ b/src/BlockRadixSortKeyValue.cs
@@ -56,14 +56,14 @@ public class BlockRadixSortKeyValue : MonoBehaviour
     private const int minSize = 15;
     private const int maxSize = 27;
 
-    private const int k_init = 0;
-    private const int k_initRandom = 1;
-    private const int k_initStability = 2;
-    private const int k_globalHist = 3;
-    private const int k_scatterOne = 4;
-    private const int k_scatterTwo = 5;
-    private const int k_scatterThree = 6;
-    private const int k_scatterFour = 7;
+    private const int k_initDescending = 1;
+    private const int k_initRandom = 2;
+    private const int k_initStability = 3;
+    private const int k_globalHist = 4;
+    private const int k_scatterOne = 5;
+    private const int k_scatterTwo = 6;
+    private const int k_scatterThree = 7;
+    private const int k_scatterFour = 8;
 
     private int radixPasses;
     private int radix;
@@ -117,7 +117,7 @@ public class BlockRadixSortKeyValue : MonoBehaviour
 
     private void Dispatcher()
     {
-        ResetBuffers();
+        ResetBuffersDescending();
 
         switch (testType)
         {
@@ -184,8 +184,8 @@ public class BlockRadixSortKeyValue : MonoBehaviour
         altBuffer = new ComputeBuffer(_size, sizeof(uint));
         altPayloadBuffer = new ComputeBuffer(_size, sizeof(uint));
 
-        compute.SetBuffer(k_init, "b_sort", sortBuffer);
-        compute.SetBuffer(k_init, "b_sortPayload", sortPayloadBuffer);
+        compute.SetBuffer(k_initDescending, "b_sort", sortBuffer);
+        compute.SetBuffer(k_initDescending, "b_sortPayload", sortPayloadBuffer);
 
         compute.SetBuffer(k_initRandom, "b_sort", sortBuffer);
         compute.SetBuffer(k_initRandom, "b_sortPayload", sortPayloadBuffer);
@@ -220,7 +220,7 @@ public class BlockRadixSortKeyValue : MonoBehaviour
     {
         globalHistBuffer = new ComputeBuffer(radix * radixPasses, sizeof(uint));
 
-        compute.SetBuffer(k_init, "b_globalHist", globalHistBuffer);
+        compute.SetBuffer(k_initDescending, "b_globalHist", globalHistBuffer);
         compute.SetBuffer(k_initRandom, "b_globalHist", globalHistBuffer);
         compute.SetBuffer(k_initStability, "b_globalHist", globalHistBuffer);
         compute.SetBuffer(k_globalHist, "b_globalHist", globalHistBuffer);
@@ -246,9 +246,9 @@ public class BlockRadixSortKeyValue : MonoBehaviour
         compute.Dispatch(k_scatterFour, 1, 1, 1);
     }
 
-    private void ResetBuffers()
+    private void ResetBuffersDescending()
     {
-        compute.Dispatch(k_init, 256, 1, 1);
+        compute.Dispatch(k_initDescending, 256, 1, 1);
     }
 
     private void ResetBuffersRandom()

--- a/src/BlockRadixSortKeyValueHelper.cs
+++ b/src/BlockRadixSortKeyValueHelper.cs
@@ -1,0 +1,149 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BlockRadixSortKeyValueHelper : MonoBehaviour
+{
+    [SerializeField]
+    private ComputeShader compute;
+
+    private const int radixPasses = 4;
+    private const int radix = 256;
+    private const string computeShaderString = "BlockRadixSortKeyValue";
+
+    private const int k_init = 0;
+    private const int k_globalHist = 4;
+    private const int k_scatterOne = 5;
+    private const int k_scatterTwo = 6;
+    private const int k_scatterThree = 7;
+    private const int k_scatterFour = 8;
+
+    private int buffer_size;
+    private ComputeBuffer altBuffer, payloadAltBuffer;
+
+    private ComputeBuffer globalHistBuffer;
+    private ComputeBuffer timingBuffer;
+
+    BlockRadixSortKeyValueHelper()
+    {
+        buffer_size = 0;
+    }
+
+    void Start()
+    {
+        CheckShader();
+
+        UpdateGlobHistBuffer();
+        UpdateTimingBuffer();
+    }
+
+    public void SortComputeBufferArray(int size, ComputeBuffer keys, ComputeBuffer payloads)
+    {
+        UpdateSize(size);
+        UpdateSortBuffers(keys, payloads);
+        ResetBuffers();
+
+        compute.Dispatch(k_globalHist, 1, 1, 1);
+
+        compute.Dispatch(k_scatterOne, 1, 1, 1);
+
+        compute.Dispatch(k_scatterTwo, 1, 1, 1);
+
+        compute.Dispatch(k_scatterThree, 1, 1, 1);
+
+        compute.Dispatch(k_scatterFour, 1, 1, 1);
+    }
+
+    private void CheckShader()
+    {
+        try
+        {
+            compute.FindKernel("InitBlockRadixSortKeyValue");
+        }
+        catch
+        {
+            Debug.LogError("Kernel(s) not found, most likely you do not have the correct compute shader attached to the game object");
+            Debug.LogError("The correct compute shader is" + computeShaderString + ". Exit play mode and attatch to the gameobject, then retry.");
+            Debug.LogError("Destroying this object.");
+            Destroy(this);
+        }
+    }
+    private void UpdateSize(int _size)
+    {
+        compute.SetInt("e_size", _size);
+
+        if (this.buffer_size < _size)
+        {
+            buffer_size = (int)(_size * 1.5);
+
+            altBuffer = new ComputeBuffer(buffer_size, sizeof(uint));
+            payloadAltBuffer = new ComputeBuffer(buffer_size, sizeof(uint));
+        }
+    }
+
+    private void UpdateSortBuffers(ComputeBuffer keys, ComputeBuffer payloads)
+    {
+        compute.SetBuffer(k_init, "b_sort", keys);
+        compute.SetBuffer(k_globalHist, "b_sort", keys);
+
+        compute.SetBuffer(k_scatterOne, "b_sort", keys);
+        compute.SetBuffer(k_scatterOne, "b_alt", altBuffer);
+        compute.SetBuffer(k_scatterOne, "b_sortPayload", payloads);
+        compute.SetBuffer(k_scatterOne, "b_altPayload", payloadAltBuffer);
+
+        compute.SetBuffer(k_scatterTwo, "b_sort", keys);
+        compute.SetBuffer(k_scatterTwo, "b_alt", altBuffer);
+        compute.SetBuffer(k_scatterTwo, "b_sortPayload", payloads);
+        compute.SetBuffer(k_scatterTwo, "b_altPayload", payloadAltBuffer);
+
+        compute.SetBuffer(k_scatterThree, "b_sort", keys);
+        compute.SetBuffer(k_scatterThree, "b_alt", altBuffer);
+        compute.SetBuffer(k_scatterThree, "b_sortPayload", payloads);
+        compute.SetBuffer(k_scatterThree, "b_altPayload", payloadAltBuffer);
+
+        compute.SetBuffer(k_scatterFour, "b_sort", keys);
+        compute.SetBuffer(k_scatterFour, "b_alt", altBuffer);
+        compute.SetBuffer(k_scatterFour, "b_sortPayload", payloads);
+        compute.SetBuffer(k_scatterFour, "b_altPayload", payloadAltBuffer);
+    }
+
+    private void UpdateGlobHistBuffer()
+    {
+        globalHistBuffer = new ComputeBuffer(radix * radixPasses, sizeof(uint));
+
+        compute.SetBuffer(k_init, "b_globalHist", globalHistBuffer);
+        compute.SetBuffer(k_globalHist, "b_globalHist", globalHistBuffer);
+        compute.SetBuffer(k_scatterOne, "b_globalHist", globalHistBuffer);
+        compute.SetBuffer(k_scatterTwo, "b_globalHist", globalHistBuffer);
+        compute.SetBuffer(k_scatterThree, "b_globalHist", globalHistBuffer);
+        compute.SetBuffer(k_scatterFour, "b_globalHist", globalHistBuffer);
+    }
+
+    private void UpdateTimingBuffer()
+    {
+        timingBuffer = new ComputeBuffer(1, sizeof(uint));
+        compute.SetBuffer(k_scatterOne, "b_timing", timingBuffer);
+        compute.SetBuffer(k_scatterFour, "b_timing", timingBuffer);
+    }
+
+    private void ResetBuffers()
+    {
+        compute.Dispatch(k_init, 256, 1, 1);
+    }
+
+
+    private void OnDestroy()
+    {
+        if (altBuffer != null)
+            altBuffer.Dispose();
+        if (payloadAltBuffer != null)
+            payloadAltBuffer.Dispose();
+
+        if (globalHistBuffer != null)
+            globalHistBuffer.Dispose();
+
+        if (timingBuffer != null)
+            timingBuffer.Dispose();
+    }
+
+}

--- a/src/OneSweepKeyValue.compute
+++ b/src/OneSweepKeyValue.compute
@@ -36,6 +36,7 @@
  ******************************************************************************/
 #pragma use_dxc
 #pragma kernel InitOneSweepKeyValue
+#pragma kernel InitDescending
 #pragma kernel InitRandom
 #pragma kernel InitStability
 #pragma kernel GlobalHistogram 
@@ -122,6 +123,25 @@ groupshared uint g_reductionHist[RADIX];                        //Shared memory 
 
 [numthreads(1024, 1, 1)]
 void InitOneSweepKeyValue(int3 id : SV_DispatchThreadID)
+{    
+    if (id.x < 1024)
+        b_globalHist[id.x] = 0;
+        
+    if (id.x < 4)
+        b_index[id.x] = 0;
+
+    const int size = BIN_PARTITIONS << RADIX_LOG;
+    for (int i = id.x; i < size; i += 1024 * 256)
+    {
+        b_passHist[i] = 0;
+        b_passTwo[i] = 0;
+        b_passThree[i] = 0;
+        b_passFour[i] = 0;
+    }
+}
+
+[numthreads(1024, 1, 1)]
+void InitDescending(int3 id : SV_DispatchThreadID)
 {
     for (int i = id.x; i < e_size; i += 1024 * 256)
     {

--- a/src/OneSweepKeyValueHelper.cs
+++ b/src/OneSweepKeyValueHelper.cs
@@ -1,0 +1,217 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class OneSweepKeyValueHelper : MonoBehaviour
+{
+    [SerializeField]
+    private ComputeShader compute;
+
+
+    private const int radixPasses = 4;
+    private const int radix = 256;
+    private const int globalHistThreadBlocks = 2048;
+    private const int partitionSize = 7680;
+    private const string computeShaderString = "OneSweepKeyValue";
+
+    private const int k_init = 0;
+    private const int k_globalHist = 4;
+    private const int k_scatterOne = 5;
+    private const int k_scatterTwo = 6;
+    private const int k_scatterThree = 7;
+    private const int k_scatterFour = 8;
+
+    private int buffer_size;
+    private ComputeBuffer altBuffer, payloadAltBuffer;
+
+    private ComputeBuffer passHistBuffer;
+    private ComputeBuffer passHistTwo;
+    private ComputeBuffer passHistThree;
+    private ComputeBuffer passHistFour;
+
+    private ComputeBuffer indexBuffer;
+    private ComputeBuffer globalHistBuffer;
+    private ComputeBuffer timingBuffer;
+
+    OneSweepKeyValueHelper()
+    {
+        buffer_size = 0;
+    }
+
+    void Start()
+    {
+        CheckShader();
+
+        UpdateGlobHistBuffer();
+        UpdateIndexBuffer();
+        UpdateTimingBuffer();
+    }
+
+    public void SortComputeBufferArray(int size, ComputeBuffer keys, ComputeBuffer payloads)
+    {
+        UpdateSize(size);
+        UpdateSortBuffers(keys, payloads);
+        ResetBuffers();
+
+        compute.Dispatch(k_globalHist, globalHistThreadBlocks, 1, 1);
+        if (size > partitionSize)
+        {
+            compute.Dispatch(k_scatterOne, size / partitionSize, 1, 1);
+            compute.Dispatch(k_scatterTwo, size / partitionSize, 1, 1);
+            compute.Dispatch(k_scatterThree, size / partitionSize, 1, 1);
+            compute.Dispatch(k_scatterFour, size / partitionSize, 1, 1);
+        }
+        else
+        {
+            compute.Dispatch(k_scatterOne, 1, 1, 1);
+            compute.Dispatch(k_scatterTwo, 1, 1, 1);
+            compute.Dispatch(k_scatterThree, 1, 1, 1);
+            compute.Dispatch(k_scatterFour, 1, 1, 1);
+        }
+    }
+
+    private void CheckShader()
+    {
+        try
+        {
+            compute.FindKernel("InitOneSweepKeyValue");
+        }
+        catch
+        {
+            Debug.LogError("Kernel(s) not found, most likely you do not have the correct compute shader attached to the game object");
+            Debug.LogError("The correct compute shader is" + computeShaderString + ". Exit play mode and attatch to the gameobject, then retry.");
+            Debug.LogError("Destroying this object.");
+            Destroy(this);
+        }
+    }
+    private void UpdateSize(int _size)
+    {
+        compute.SetInt("e_size", _size);
+
+        if (this.buffer_size < _size)
+        {
+            if (passHistBuffer != null)
+                passHistBuffer.Dispose();
+            if (passHistTwo != null)
+                passHistTwo.Dispose();
+            if (passHistThree != null)
+                passHistThree.Dispose();
+            if (passHistFour != null)
+                passHistFour.Dispose();
+
+            buffer_size = (int)(_size * 1.5);
+
+            altBuffer = new ComputeBuffer(buffer_size, sizeof(uint));
+            payloadAltBuffer = new ComputeBuffer(buffer_size, sizeof(uint));
+
+            passHistBuffer = new ComputeBuffer(buffer_size / partitionSize * radix, sizeof(uint));
+            passHistTwo = new ComputeBuffer(buffer_size / partitionSize * radix, sizeof(uint));
+            passHistThree = new ComputeBuffer(buffer_size / partitionSize * radix, sizeof(uint));
+            passHistFour = new ComputeBuffer(buffer_size / partitionSize * radix, sizeof(uint));
+        }
+
+        UpdatePassHistBuffer(_size);
+    }
+
+    private void UpdateSortBuffers(ComputeBuffer keys, ComputeBuffer payloads)
+    {
+        compute.SetBuffer(k_init, "b_sort", keys);
+        compute.SetBuffer(k_globalHist, "b_sort", keys);
+
+        compute.SetBuffer(k_scatterOne, "b_sort", keys);
+        compute.SetBuffer(k_scatterOne, "b_alt", altBuffer);
+        compute.SetBuffer(k_scatterOne, "b_sortPayload", payloads);
+        compute.SetBuffer(k_scatterOne, "b_altPayload", payloadAltBuffer);
+
+        compute.SetBuffer(k_scatterTwo, "b_sort", keys);
+        compute.SetBuffer(k_scatterTwo, "b_alt", altBuffer);
+        compute.SetBuffer(k_scatterTwo, "b_sortPayload", payloads);
+        compute.SetBuffer(k_scatterTwo, "b_altPayload", payloadAltBuffer);
+
+        compute.SetBuffer(k_scatterThree, "b_sort", keys);
+        compute.SetBuffer(k_scatterThree, "b_alt", altBuffer);
+        compute.SetBuffer(k_scatterThree, "b_sortPayload", payloads);
+        compute.SetBuffer(k_scatterThree, "b_altPayload", payloadAltBuffer);
+
+        compute.SetBuffer(k_scatterFour, "b_sort", keys);
+        compute.SetBuffer(k_scatterFour, "b_alt", altBuffer);
+        compute.SetBuffer(k_scatterFour, "b_sortPayload", payloads);
+        compute.SetBuffer(k_scatterFour, "b_altPayload", payloadAltBuffer);
+    }
+
+    private void UpdatePassHistBuffer(int _size)
+    {
+        //init
+        compute.SetBuffer(k_init, "b_passHist", passHistBuffer);
+        compute.SetBuffer(k_init, "b_passTwo", passHistTwo);
+        compute.SetBuffer(k_init, "b_passThree", passHistThree);
+        compute.SetBuffer(k_init, "b_passFour", passHistFour);
+
+        //scatters
+        compute.SetBuffer(k_scatterOne, "b_passHist", passHistBuffer);
+        compute.SetBuffer(k_scatterTwo, "b_passTwo", passHistTwo);
+        compute.SetBuffer(k_scatterThree, "b_passThree", passHistThree);
+        compute.SetBuffer(k_scatterFour, "b_passFour", passHistFour);
+    }
+
+    private void UpdateGlobHistBuffer()
+    {
+        globalHistBuffer = new ComputeBuffer(radix * radixPasses, sizeof(uint));
+
+        compute.SetBuffer(k_init, "b_globalHist", globalHistBuffer);
+        compute.SetBuffer(k_globalHist, "b_globalHist", globalHistBuffer);
+        compute.SetBuffer(k_scatterOne, "b_globalHist", globalHistBuffer);
+        compute.SetBuffer(k_scatterTwo, "b_globalHist", globalHistBuffer);
+        compute.SetBuffer(k_scatterThree, "b_globalHist", globalHistBuffer);
+        compute.SetBuffer(k_scatterFour, "b_globalHist", globalHistBuffer);
+    }
+    private void UpdateIndexBuffer()
+    {
+        indexBuffer = new ComputeBuffer(radixPasses, sizeof(uint));
+
+        compute.SetBuffer(k_init, "b_index", indexBuffer);
+
+        compute.SetBuffer(k_scatterOne, "b_index", indexBuffer);
+        compute.SetBuffer(k_scatterTwo, "b_index", indexBuffer);
+        compute.SetBuffer(k_scatterThree, "b_index", indexBuffer);
+        compute.SetBuffer(k_scatterFour, "b_index", indexBuffer);
+    }
+    private void UpdateTimingBuffer()
+    {
+        timingBuffer = new ComputeBuffer(1, sizeof(uint));
+        compute.SetBuffer(k_scatterOne, "b_timing", timingBuffer);
+        compute.SetBuffer(k_scatterFour, "b_timing", timingBuffer);
+    }
+
+    private void ResetBuffers()
+    {
+        compute.Dispatch(k_init, 256, 1, 1);
+    }
+
+
+    private void OnDestroy()
+    {
+        if (altBuffer != null)
+            altBuffer.Dispose();
+        if (payloadAltBuffer != null)
+            payloadAltBuffer.Dispose();
+
+        if (globalHistBuffer != null)
+            globalHistBuffer.Dispose();
+        if (indexBuffer != null)
+            indexBuffer.Dispose();
+
+        if (passHistBuffer != null)
+            passHistBuffer.Dispose();
+        if (passHistTwo != null)
+            passHistTwo.Dispose();
+        if (passHistThree != null)
+            passHistThree.Dispose();
+        if (passHistFour != null)
+            passHistFour.Dispose();
+
+        if (timingBuffer != null)
+            timingBuffer.Dispose();
+    }
+
+}


### PR DESCRIPTION
Thanks for the update. I've made helper classes for `BlockRadixSortKeyValue` and `OneSweepKeyValue` respectively in case anyone reaches here and wants to just plug and play.

```
[SerializeField] BlockRadixSortKeyValueHelper sortHelper;

public int size;
public ComputeBuffer keys;
public ComputeBuffer values;

keys = new ComputeBuffer(size, sizeof(uint));
values = new ComputeBuffer(size, sizeof(uint));

// set actual data
// ......

sortHelper.SortComputeBufferArray(size, keys, values);
```
-----
Currently `BlockRadixSortKeyValue` works perfectly fine, but `OneSweepKeyValue` has an issue.
In `OneSweepKeyValue` when the size is not dividable by `partitionSize`, the sorting result is unreliable.

